### PR TITLE
[bugfix] add gunicorn to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ pytest-order = "~=1.0.1"
 pytest-sugar = "~=0.9.4"
 pytest-mock = "~=3.10.0"
 coverage = "~=6.3.2"
+gunicorn = "~=20.1.0"
 
 [dev-packages]
 


### PR DESCRIPTION
## Why need this change? / Root cause: 
- `pipfile` missing `gunicorn` dependency that causes CD failed
## Changes made:
- add `gunicorn` dependency to `pipfile`
## Test Scope / Change impact:
- CD should works

