### PR TITLE
[Dev] keep scheduler job after thread started

### DIFF
--- a/pt_scheduler.py
+++ b/pt_scheduler.py
@@ -1,21 +1,15 @@
 import logging
-import threading
 import time
 
 import schedule
 
 import pt_config
-import pt_scheduler
 import pt_service
 
 logger = logging.getLogger("Scheduler")
 
 if __name__ == "__main__":
-    threading.Thread(target=pt_scheduler.my_job).start()
     logger.info("Momo price tracker scheduler started.")
-
-
-def my_job():
     schedule.every(pt_config.PERIOD_HOUR).hours.do(pt_service.sync_price)
     schedule.every(pt_config.PERIOD_HOUR).hours.do(pt_service.disable_not_active_user_sub_good)
     while True:


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 原先的寫法會造成 main thread 提前結束，但後面的 scheduler thread 還在運作，會發生不預期的錯誤
## Changes made:
-
## Test Scope / Change impact:
-

